### PR TITLE
Add more namespaced vector constants

### DIFF
--- a/src/raymath.nim
+++ b/src/raymath.nim
@@ -43,6 +43,14 @@ func one*(_: typedesc[Vector2]): Vector2 {.inline.} =
   ## Vector with components value 1'f32
   result = Vector2(x: 1, y: 1)
 
+func unitX*(_: typedesc[Vector2]): Vector2 {.inline.} =
+  ## Unit vector along X axis
+  result = Vector2(x: 1, y: 0)
+
+func unitY*(_: typedesc[Vector2]): Vector2 {.inline.} =
+  ## Unit vector along Y axis
+  result = Vector2(x: 0, y: 1)
+
 func equals*(p, q: Vector2, tol = 1.0e-6'f32): bool {.inline.} =
   ## Check whether two given vectors are almost equal
   result = abs(p.x - q.x) <= tol * max(1'f32, max(abs(p.x), abs(q.x))) and
@@ -232,6 +240,18 @@ func zero*(_: typedesc[Vector3]): Vector3 {.inline.} =
 func one*(_: typedesc[Vector3]): Vector3 {.inline.} =
   ## Vector with components value 1'f32
   result = Vector3(x: 1, y: 1, z: 1)
+
+func unitX*(_: typedesc[Vector3]): Vector3 {.inline.} =
+  ## Unit vector along X axis
+  result = Vector3(x: 1, y: 0, z: 0)
+
+func unitY*(_: typedesc[Vector3]): Vector3 {.inline.} =
+  ## Unit vector along Y axis
+  result = Vector3(x: 0, y: 1, z: 0)
+
+func unitZ*(_: typedesc[Vector3]): Vector3 {.inline.} =
+  ## Unit vector along Z axis
+  result = Vector3(x: 0, y: 0, z: 1)
 
 func equals*(p, q: Vector3, tol = 1.0e-6'f32): bool {.inline.} =
   ## Check whether two given vectors are almost equal
@@ -654,7 +674,23 @@ func zero*(_: typedesc[Vector4]): Vector4 {.inline.} =
 
 func one*(_: typedesc[Vector4]): Vector4 {.inline.} =
   ## Vector with components value 1'f32
-  result = Vector2(x: 1, y: 1, z: 1, w: 1)
+  result = Vector4(x: 1, y: 1, z: 1, w: 1)
+
+func unitX*(_: typedesc[Vector4]): Vector4 {.inline.} =
+  ## Unit vector along X axis
+  result = Vector4(x: 1, y: 0, z: 0, w: 0)
+
+func unitY*(_: typedesc[Vector4]): Vector4 {.inline.} =
+  ## Unit vector along Y axis
+  result = Vector4(x: 0, y: 1, z: 0, w: 0)
+
+func unitZ*(_: typedesc[Vector4]): Vector4 {.inline.} =
+  ## Unit vector along Z axis
+  result = Vector4(x: 0, y: 0, z: 1, w: 0)
+
+func unitW*(_: typedesc[Vector4]): Vector4 {.inline.} =
+  ## Unit vector along W axis
+  result = Vector4(x: 0, y: 0, z: 0, w: 1)
 
 func equals*(p, q: Vector4, tol = 1.0e-6'f32): bool {.inline.} =
   ## Check whether two given quaternions are almost equal


### PR DESCRIPTION
AI generated, prompt:

```
Here's some C++ constants:

static constexpr Vector2 Vector2Zeros = { 0, 0 };
static constexpr Vector2 Vector2Ones = { 1, 1 };
static constexpr Vector2 Vector2UnitX = { 1, 0 };
static constexpr Vector2 Vector2UnitY = { 0, 1 };

static constexpr Vector3 Vector3Zeros = { 0, 0, 0 };
static constexpr Vector3 Vector3Ones = { 1, 1, 1 };
static constexpr Vector3 Vector3UnitX = { 1, 0, 0 };
static constexpr Vector3 Vector3UnitY = { 0, 1, 0 };
static constexpr Vector3 Vector3UnitZ = { 0, 0, 1 };

static constexpr Vector4 Vector4Zeros = { 0, 0, 0, 0 };
static constexpr Vector4 Vector4Ones = { 1, 1, 1, 1 };
static constexpr Vector4 Vector4UnitX = { 1, 0, 0, 0 };
static constexpr Vector4 Vector4UnitY = { 0, 1, 0, 0 };
static constexpr Vector4 Vector4UnitZ = { 0, 0, 1, 0 };
static constexpr Vector4 Vector4UnitW = { 0, 0, 0, 1 };

Translate them to nim but don't use const instead use templates that have typedesc parameters, like this:

func zeros*(_: typedesc[Vector2]): Vector2 {.inline.} =
  ## Vector with components value 0'f32
  result = Vector2(x: 0, y: 0)

func ones*(_: typedesc[Vector2]): Vector2 {.inline.} =
  ## Vector with components value 1'f32
  result = Vector2(x: 1, y: 1)

Translate the rest to nim.
```