### PR TITLE
Add support for cross compilation (fix paths)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install dependencies
       run: |
-        sudo apt install libasound2-dev libx11-dev libxrandr-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev libxcursor-dev libxinerama-dev libwayland-dev libxkbcommon-dev libwayland-bin
+        sudo apt install libasound2-dev libx11-dev libxrandr-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev libxcursor-dev libxinerama-dev libwayland-dev libxkbcommon-dev libwayland-bin mingw-w64
     - name: Set up Emscripten
       run: |
         git clone https://github.com/emscripten-core/emsdk.git

--- a/naylib.nimble
+++ b/naylib.nimble
@@ -56,4 +56,6 @@ task test, "Runs the test suite":
   exec "nim c -d:release tests/basic_window.nim"
   when defined(linux):
     exec "nim c -d:release -d:wayland tests/basic_window.nim"
+    # cross-compile to windows
+    exec "nim c -d:release -d:mingw tests/basic_window.nim"
   exec "nim c -d:release -d:emscripten tests/basic_window_web.nim"

--- a/src/raylib.nim
+++ b/src/raylib.nim
@@ -122,7 +122,7 @@ when defined(emscripten): discard
 elif defined(android): discard
 elif defined(macosx):
   const glfwBuildOSPath = buildOSPath(raylibDir / Path"rglfw.c")
-  {.compile(glfwPath, "-x objective-c").}
+  {.compile(glfwBuildOSPath, "-x objective-c").}
 else: {.compile: buildOSPath(raylibDir / Path"rglfw.c").}
 {.compile: buildOSPath(raylibDir / Path"rcore.c").}
 {.compile: buildOSPath(raylibDir / Path"rshapes.c").}


### PR DESCRIPTION
Support compile to Windows on Linux (-d:mingw)

Exports a proc `buildOSPath` that tools/projects using naylib can use to fix paths too (such as naygui).