### PR TITLE
fix: guard Texture/RenderTexture/Font =destroy with validity checks

### DIFF
--- a/src/raylib.nim
+++ b/src/raylib.nim
@@ -1775,17 +1775,17 @@ proc `=copy`*(dest: var Image; source: Image) =
     dest = imageCopy(source) # generates =sink
 
 proc `=destroy`*(x: Texture) =
-  unloadTexture(x)
+  if isTextureValid(x): unloadTexture(x)
 proc `=dup`*(source: Texture): Texture {.error.}
 proc `=copy`*(dest: var Texture; source: Texture) {.error.}
 
 proc `=destroy`*(x: RenderTexture) =
-  unloadRenderTexture(x)
+  if isRenderTextureValid(x): unloadRenderTexture(x)
 proc `=dup`*(source: RenderTexture): RenderTexture {.error.}
 proc `=copy`*(dest: var RenderTexture; source: RenderTexture) {.error.}
 
 proc `=destroy`*(x: Font) =
-  unloadFont(x)
+  if isFontValid(x): unloadFont(x)
 proc `=dup`*(source: Font): Font {.error.}
 proc `=copy`*(dest: var Font; source: Font) {.error.}
 


### PR DESCRIPTION
When a Font, Texture, or RenderTexture is declared at proc scope and closeWindow() is the last explicit statement, Nim/ORC calls =destroy after closeWindow() returns — by which point the OpenGL context has been destroyed on Linux, causing a SIGSEGV.

Guard each destructor with the corresponding validity check so the unload call is a no-op once the resource or context is gone:

  Texture      → isTextureValid(x)
  RenderTexture → isRenderTextureValid(x)
  Font          → isFontValid(x)

Repro: declare `let font = loadFont(...)` in a proc, call closeWindow() as the last statement, observe SIGSEGV on Linux exit. With this fix the destructor is silently skipped.

Workaround (still recommended): wrap Raylib resource allocations in a block scope so =destroy fires before closeWindow().